### PR TITLE
fix!: expect correct google cloud storage abbreviation in query scheme (gcs://)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           poetry run python tests/test_fake_gcs.py
 
       - name: Run pytest
-        run: poetry run coverage run -m pytest tests/tests.py
+        run: poetry run coverage run -m pytest -v tests/tests.py
 
       - name: Run Coverage
         run: poetry run coverage report -m

--- a/snakemake_storage_plugin_gcs/__init__.py
+++ b/snakemake_storage_plugin_gcs/__init__.py
@@ -189,11 +189,11 @@ class StorageProvider(StorageProviderBase):
                 valid=False,
                 reason=f"cannot be parsed as URL ({e})",
             )
-        if parsed.scheme != "gs":
+        if parsed.scheme != "gcs":
             return StorageQueryValidationResult(
                 query=query,
                 valid=False,
-                reason="must start with gs (gs://...)",
+                reason="must start with gcs scheme (gcs://...)",
             )
         return StorageQueryValidationResult(
             query=query,
@@ -207,7 +207,7 @@ class StorageProvider(StorageProviderBase):
         """
         return [
             ExampleQuery(
-                query="gs://mybucket/myfile.txt",
+                query="gcs://mybucket/myfile.txt",
                 type=QueryType.ANY,
                 description="A file in an google storage (GCS) bucket",
             )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -14,6 +14,7 @@ os.environ["STORAGE_EMULATOR_HOST"] = "http://localhost:4443"
 
 class TestStorage(TestStorageBase):
     __test__ = True
+    files_only = False
 
     def get_query(self, tmp_path) -> str:
         return "gs://snakemake-test-bucket/test-file.txt"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -17,12 +17,12 @@ class TestStorage(TestStorageBase):
     files_only = False
 
     def get_query(self, tmp_path) -> str:
-        return "gs://snakemake-test-bucket/test-file.txt"
+        return "gcs://snakemake-test-bucket/test-file.txt"
 
     def get_query_not_existing(self, tmp_path) -> str:
         bucket = uuid.uuid4().hex
         key = uuid.uuid4().hex
-        return f"gs://{bucket}/{key}"
+        return f"gcs://{bucket}/{key}"
 
     def get_storage_provider_cls(self) -> Type[StorageProviderBase]:
         # Return the StorageProvider class of this plugin


### PR DESCRIPTION
I am sorry for the breaking change. This is unavoidable unfortunately, in order to have a consistent experience. GCS seems to be the official abbreviation of google cloud storage.