### PR TITLE
fix: download_directory local path incorrectly stored

### DIFF
--- a/snakemake_storage_plugin_gcs/__init__.py
+++ b/snakemake_storage_plugin_gcs/__init__.py
@@ -525,7 +525,8 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         self.local_path().mkdir(exist_ok=True)
 
         for blob in self.directory_entries():
-            local_name = f"{blob.bucket.name}/{blob.name}"
+            # local_name = f"{blob.bucket.name}/{blob.name}"
+            local_name = self.provider.local_prefix  / self.bucket.name / blob.name
 
             # Don't try to create "directory blob"
             if os.path.exists(local_name) and os.path.isdir(local_name):

--- a/snakemake_storage_plugin_gcs/__init__.py
+++ b/snakemake_storage_plugin_gcs/__init__.py
@@ -525,8 +525,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         self.local_path().mkdir(exist_ok=True)
 
         for blob in self.directory_entries():
-            # local_name = f"{blob.bucket.name}/{blob.name}"
-            local_name = self.provider.local_prefix  / self.bucket.name / blob.name
+            local_name = self.provider.local_prefix / self.bucket.name / blob.name
 
             # Don't try to create "directory blob"
             if os.path.exists(local_name) and os.path.isdir(local_name):

--- a/snakemake_storage_plugin_gcs/__init__.py
+++ b/snakemake_storage_plugin_gcs/__init__.py
@@ -533,7 +533,9 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
             # The results list is either `None` or an exception for each blob in
             # the input list, in order.
             if isinstance(result, Exception):
-                self.logger.error("Failed to download {} due to exception: {}".format(name, result))
+                self.logger.error(
+                    "Failed to download {} due to exception: {}".format(name, result)
+                )
 
     @lazy_property
     def bucket(self):

--- a/snakemake_storage_plugin_gcs/__init__.py
+++ b/snakemake_storage_plugin_gcs/__init__.py
@@ -533,7 +533,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
             # The results list is either `None` or an exception for each blob in
             # the input list, in order.
             if isinstance(result, Exception):
-                print("Failed to download {} due to exception: {}".format(name, result))
+                self.logger.error("Failed to download {} due to exception: {}".format(name, result))
 
     @lazy_property
     def bucket(self):

--- a/snakemake_storage_plugin_gcs/__init__.py
+++ b/snakemake_storage_plugin_gcs/__init__.py
@@ -30,6 +30,7 @@ import os
 from pathlib import Path
 import google.cloud.exceptions
 from google.cloud import storage
+from google.cloud.storage import transfer_manager
 from google.api_core import retry
 from google_crc32c import Checksum
 
@@ -521,17 +522,18 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         """
         Handle download of a storage folder (assists retrieve_blob)
         """
-        # Create the directory locally
-        self.local_path().mkdir(exist_ok=True)
-
-        for blob in self.directory_entries():
-            local_name = self.provider.local_prefix / self.bucket.name / blob.name
-
-            # Don't try to create "directory blob"
-            if os.path.exists(local_name) and os.path.isdir(local_name):
-                continue
-
-            download_blob(blob, local_name)
+        blob_names = [blob.name for blob in self.directory_entries()]
+        results = transfer_manager.download_many_to_path(
+            bucket=self.bucket,
+            blob_names=blob_names,
+            destination_directory=self.provider.local_prefix / self.bucket.name,
+            create_directories=True,
+        )
+        for name, result in zip(blob_names, results):
+            # The results list is either `None` or an exception for each blob in
+            # the input list, in order.
+            if isinstance(result, Exception):
+                print("Failed to download {} due to exception: {}".format(name, result))
 
     @lazy_property
     def bucket(self):


### PR DESCRIPTION
when specifying a directory for input, or using the output from a previous rule that is marked with `directory()` the directory downloads directory into the `workdir` instead of into `.snakemake/storage/gcs`

This fix should hopefully fix that. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a Google Cloud Storage (GCS) storage provider with enhanced configuration options.
	- Added functionality for file integrity checks during downloads.
	- Implemented methods for managing storage objects, including existence checks, metadata retrieval, and directory uploads.
	- Enhanced query handling and rate limiting for GCS interactions.
	- Improved efficiency in downloading multiple blobs with directory support.

- **Bug Fixes**
	- Improved error handling with retry logic for transient issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->