### PR TITLE
fix: Remove the redundant --keep-local option

### DIFF
--- a/snakemake_storage_plugin_gcs/__init__.py
+++ b/snakemake_storage_plugin_gcs/__init__.py
@@ -51,15 +51,6 @@ class StorageProviderSettings(StorageProviderSettingsBase):
             "required": True,
         },
     )
-    keep_local: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "keep local copy of storage object(s)",
-            "env_var": False,
-            "required": False,
-            "type": bool,
-        },
-    )
     stay_on_remote: Optional[bool] = field(
         default=False,
         metadata={


### PR DESCRIPTION
The PR removes the `--storage-gcs-keep-local` option. The option is non-functional and is already covered by Snakemake's option `--keep-storage-local-copies`.  I propose a fix for the general `keep-local` functionality in snakemake/snakemake#3358

Closes #56.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the storage provider configuration by removing the option to keep local copies of storage objects, while continuing to support remote storage management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->